### PR TITLE
Switch to neon-fp-armv8

### DIFF
--- a/Dockerfile.linux-builder
+++ b/Dockerfile.linux-builder
@@ -1,6 +1,6 @@
 FROM almalinux:8
 
 RUN yum -y update && \
-    yum -y install make ncurses-devel which unzip perl cpio rsync fileutils bc bzip2 gzip sed git python3 file patch wget perl-Thread-Queue perl-Data-Dumper perl-ExtUtils-MakeMaker perl-IPC-Cmd gcc gcc-c++ && \
+    yum -y install make ncurses-devel which unzip perl cpio rsync fileutils diffutils bc bzip2 gzip sed git python3 file patch wget perl-Thread-Queue perl-Data-Dumper perl-ExtUtils-MakeMaker perl-IPC-Cmd gcc gcc-c++ && \
     yum clean all
 

--- a/config-godot-armv7
+++ b/config-godot-armv7
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot 2023.08.2-49-gda7f6df0ba Configuration
+# Buildroot 2023.08.4-8-g689b43e9a0 Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_9=y
@@ -47,7 +47,7 @@ BR2_NORMALIZED_ARCH="arm"
 BR2_ENDIAN="LITTLE"
 BR2_GCC_TARGET_ABI="aapcs-linux"
 BR2_GCC_TARGET_CPU="cortex-a57"
-BR2_GCC_TARGET_FPU="fp-armv8"
+BR2_GCC_TARGET_FPU="neon-fp-armv8"
 BR2_GCC_TARGET_FLOAT_ABI="hard"
 BR2_GCC_TARGET_MODE="arm"
 BR2_BINFMT_SUPPORTS_SHARED=y
@@ -145,8 +145,8 @@ BR2_ARM_EABIHF=y
 # BR2_ARM_FPU_VFPV4D16 is not set
 # BR2_ARM_FPU_NEON is not set
 # BR2_ARM_FPU_NEON_VFPV4 is not set
-BR2_ARM_FPU_FP_ARMV8=y
-# BR2_ARM_FPU_NEON_FP_ARMV8 is not set
+# BR2_ARM_FPU_FP_ARMV8 is not set
+BR2_ARM_FPU_NEON_FP_ARMV8=y
 BR2_ARM_INSTRUCTIONS_ARM=y
 # BR2_ARM_INSTRUCTIONS_THUMB2 is not set
 BR2_BINFMT_ELF=y
@@ -181,7 +181,7 @@ BR2_KERNEL_HEADERS_5_15=y
 # BR2_KERNEL_HEADERS_VERSION is not set
 # BR2_KERNEL_HEADERS_CUSTOM_TARBALL is not set
 # BR2_KERNEL_HEADERS_CUSTOM_GIT is not set
-BR2_DEFAULT_KERNEL_HEADERS="5.15.137"
+BR2_DEFAULT_KERNEL_HEADERS="5.15.140"
 BR2_PACKAGE_LINUX_HEADERS=y
 BR2_PACKAGE_MUSL_ARCH_SUPPORTS=y
 BR2_PACKAGE_MUSL_SUPPORTS=y
@@ -394,6 +394,10 @@ BR2_GLOBAL_PATCH_DIR=""
 # Advanced
 #
 # BR2_FORCE_HOST_BUILD is not set
+
+#
+# Forcing all downloads to have a valid hash needs a global patch and hash directory
+#
 # BR2_REPRODUCIBLE is not set
 # BR2_PER_PACKAGE_DIRECTORIES is not set
 
@@ -2970,10 +2974,6 @@ BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 # pamtester depends on linux-pam
 #
 # BR2_PACKAGE_PETITBOOT is not set
-
-#
-# petitboot needs a uClibc or glibc toolchain w/ wchar, dynamic library, threads, udev /dev management
-#
 # BR2_PACKAGE_POLKIT is not set
 # BR2_PACKAGE_PROCPS_NG is not set
 # BR2_PACKAGE_PROCRANK_LINUX is not set


### PR DESCRIPTION
The previous versions of the SDKs had this, but was accidentally dropped when rebasing on the newer buildroot.